### PR TITLE
Add playable chess board to admin dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,6 +89,11 @@ def index():
         total_members=total_members
     )
 
+@app.route('/board')
+def board():
+    # Display an interactive chess board for two players on the same device.
+    return render_template('board.html')
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     # Admin login route. Only users in the users table can log in.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1637,3 +1637,15 @@ a.no-underline {
         margin-bottom: 0.7rem;
     }
 }
+/* --- Board Page Styles --- */
+.board-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+#board {
+    width: 400px;
+    max-width: 100%;
+}

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -1,0 +1,53 @@
+// Initializes a local two-player chess game using chess.js and chessboard.js.
+document.addEventListener('DOMContentLoaded', function () {
+    const boardElement = document.getElementById('board');
+    if (!boardElement) return;
+
+    const game = new Chess();
+    const statusEl = document.getElementById('status');
+
+    function updateStatus() {
+        let status = '';
+        const moveColor = game.turn() === 'w' ? 'White' : 'Black';
+
+        if (game.in_checkmate()) {
+            status = 'Game over, ' + moveColor + ' is in checkmate.';
+        } else if (game.in_draw()) {
+            status = 'Game over, drawn position.';
+        } else {
+            status = moveColor + ' to move';
+            if (game.in_check()) {
+                status += ', ' + moveColor + ' is in check.';
+            }
+        }
+        statusEl.textContent = status;
+    }
+
+    const board = Chessboard('board', {
+        draggable: true,
+        position: 'start',
+        onDragStart: function (source, piece) {
+            if (game.game_over()) return false;
+            if ((game.turn() === 'w' && piece.search(/^b/) !== -1) ||
+                (game.turn() === 'b' && piece.search(/^w/) !== -1)) {
+                return false;
+            }
+        },
+        onDrop: function (source, target) {
+            const move = game.move({ from: source, to: target, promotion: 'q' });
+            if (move === null) return 'snapback';
+            updateStatus();
+        },
+        onSnapEnd: function () {
+            board.position(game.fen());
+        }
+    });
+
+    document.getElementById('resetBoard').addEventListener('click', function () {
+        game.reset();
+        board.start();
+        updateStatus();
+    });
+
+    updateStatus();
+});

--- a/templates/board.html
+++ b/templates/board.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard.min.css">
+<div class="board-container">
+    <div id="board"></div>
+    <p id="status"></p>
+    <button id="resetBoard" class="btn-secondary">Reset Game</button>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/1.0.0/chess.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard.min.js"></script>
+<script src="{{ url_for('static', filename='js/board.js') }}"></script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,9 @@
     </div>
     <!-- Quick action buttons for admins -->
     <div class="dashboard-actions">
+        <a href="{{ url_for('board') }}" class="btn-primary">
+            <i class="fa-solid fa-chess-board icon-left"></i>Open Chess Board
+        </a>
         {% if session.username %}
         <a href="{{ url_for('create_tournament') }}" class="btn-primary">
             <i class="fa-solid fa-plus icon-left"></i>Create New Tournament


### PR DESCRIPTION
## Summary
- add dashboard button linking to a live chess board
- implement board page powered by chess.js and chessboard.js
- include styling and client-side logic for two-player games

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895d2660a588321bc0e6ed9358e1c45